### PR TITLE
feat(createParser): support custom whitespace/character functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,19 @@
 const identity = x => x;
 
-const isRawStringChar = c =>
+const defaultIsRawStringChar = c =>
   c === "-" ||
   c === "_" ||
   (c >= "0" && c <= "9") ||
   (c >= "A" && c <= "Z") ||
   (c >= "a" && c <= "z");
 
-const isWhitespace = c => c === " " || c === "\n" || c === "\r";
+const defaultIsWhitespace = c => c === " " || c === "\n" || c === "\r";
 
 export const createParser = ({
   keyTransform = identity,
   valueTransform = identity,
+  isRawStringChar = defaultIsRawStringChar, // Unstable property - See #11
+  isWhitespace = defaultIsWhitespace, // Unstable property - See #11
 } = {}) => {
   let i, input, n, pairs;
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -27,4 +27,37 @@ describe("createParser()", () => {
       AGE: 68,
     });
   });
+
+  it("supports custom characters as non-delimiters", () => {
+    const parse = createParser({
+      isRawStringChar: c =>
+        c === "!" ||
+        (c >= "0" && c <= "9") ||
+        (c >= "A" && c <= "Z") ||
+        (c >= "a" && c <= "z"),
+    });
+
+    expect(parse("key:!value")).toEqual({
+      key: "!value",
+    });
+
+    expect(parse("key!:value")).toEqual({
+      "key!": "value",
+    });
+
+    expect(parse("key_value")).toEqual({
+      key: "value",
+    });
+  });
+
+  it("supports custom whitespace characters", () => {
+    const parse = createParser({
+      isWhitespace: c => c === "%",
+    });
+
+    expect(parse("%KEY1=value1%KEY2=value2%")).toEqual({
+      KEY1: "value1",
+      KEY2: "value2",
+    });
+  });
 });


### PR DESCRIPTION
Currently it's not possible to specify special characters that should be handled differently (ex. I want to include "!" by default in the key or value and not treat it as a separator). While using quotes is one workaround, allowing my app to overwrite the default can help make it a nicer experience for users to avoid quotes when they're not needed.